### PR TITLE
Use LevelID as ArcGIS cache gridset's name

### DIFF
--- a/geowebcache/arcgiscache/src/main/java/org/geowebcache/arcgis/layer/GridSetBuilder.java
+++ b/geowebcache/arcgiscache/src/main/java/org/geowebcache/arcgis/layer/GridSetBuilder.java
@@ -71,6 +71,7 @@ class GridSetBuilder {
             resolutions = resAndScales[0];
 
             double[] scales = resAndScales[1];
+            scaleNames = resAndScales[2];
             // TODO: check whether pixelSize computed above should be used instead
             metersPerUnit = (GridSetFactory.DEFAULT_PIXEL_SIZE_METER * scales[0]) / resolutions[0];
         }
@@ -126,12 +127,13 @@ class GridSetBuilder {
 
     private double[][] getResolutions(List<LODInfo> lodInfos) {
         final int numLevelsOfDetail = lodInfos.size();
-        double[][] resolutionsAndScales = new double[2][numLevelsOfDetail];
+        double[][] resolutionsAndScales = new double[3][numLevelsOfDetail];
         LODInfo lodInfo;
         for (int i = 0; i < numLevelsOfDetail; i++) {
             lodInfo = lodInfos.get(i);
             resolutionsAndScales[0][i] = lodInfo.getResolution();
             resolutionsAndScales[1][i] = lodInfo.getScale();
+            resolutionsAndScales[2][i] = lodInfo.getLevelID();
         }
         return resolutionsAndScales;
     }


### PR DESCRIPTION
Arcgis cache layer extension does not assign any scale name to gridsets, so `GridSetFactory` make it as `gridsetName:i` , like `EPSG:4326_arcgis:0`. This patch use `levelID`, like `0`, `1`, `2` ..., as scaleName, and it is correspond with our practice in WMTS.